### PR TITLE
Fixed timeout reporting for unban/unmutes

### DIFF
--- a/database/init.js
+++ b/database/init.js
@@ -65,6 +65,7 @@ initStatements.push(
     serverId TEXT REFERENCES servers(serverId) ON DELETE CASCADE,
     userId TEXT NOT NULL,
     type TEXT NOT NULL,
+    startTime INTEGER NOT NULL,
     endTime INTEGER NOT NULL,
     timerId INTEGER NOT NULL,
     PRIMARY KEY(serverId, userId, type)

--- a/src/main/command/moderationcommands/BanCommand.ts
+++ b/src/main/command/moderationcommands/BanCommand.ts
@@ -77,7 +77,7 @@ export class BanCommand extends Command {
             if (duration) {
                 const endTime = curTime + duration;
                 ModUtils.addBanTimeout(
-                    duration, endTime, targetId, server.serverId, botId!, members!, emit!,
+                    duration, curTime, endTime, targetId, server.serverId, botId!, members!, emit!,
                 );
             }
             await messageReply(this.generateValidEmbed(target, reason, duration));

--- a/src/main/command/moderationcommands/MuteCommand.ts
+++ b/src/main/command/moderationcommands/MuteCommand.ts
@@ -90,7 +90,7 @@ export class MuteCommand extends Command {
             if (duration) {
                 const endTime = curTime + duration;
                 ModUtils.addMuteTimeout(
-                    duration, endTime, targetId, server.serverId,
+                    duration, curTime, endTime, targetId, server.serverId,
                     botId!, members!, emit!, muteRoleId,
                 );
             }

--- a/src/main/command/moderationcommands/WarnCommand.ts
+++ b/src/main/command/moderationcommands/WarnCommand.ts
@@ -106,7 +106,7 @@ export class WarnCommand extends Command {
                     if (duration) {
                         const endTime = curTime + duration;
                         ModUtils.addBanTimeout(
-                            duration, endTime, targetId, serverId, botId, members!, emit,
+                            duration, curTime, endTime, targetId, serverId, botId, members!, emit,
                         );
                     }
                     break;
@@ -132,7 +132,7 @@ export class WarnCommand extends Command {
                     if (duration) {
                         const endTime = curTime + duration;
                         ModUtils.addMuteTimeout(
-                            duration, endTime, targetId, serverId,
+                            duration, curTime, endTime, targetId, serverId,
                             botId!, members!, emit!, muteRoleId,
                         );
                     }

--- a/src/main/modules/moderation/ModDbUtils.ts
+++ b/src/main/modules/moderation/ModDbUtils.ts
@@ -22,6 +22,7 @@ export class ModDbUtils {
     /**
      * Adds an action with a timeout into the timeout database, updates on conflict of pkeys
      *
+     * @param  {number} startTIme
      * @param  {number} endTime
      * @param  {string} userId
      * @param  {ModActions} type
@@ -29,13 +30,13 @@ export class ModDbUtils {
      * @param  {number} timerId
      * @returns void
      */
-    public static addActionTimeout(endTime: number, userId: string, type: ModActions,
-                                   serverId: string, timerId: number): void {
+    public static addActionTimeout(startTime: number, endTime: number, userId: string,
+                                   type: ModActions, serverId: string, timerId: number): void {
         const db = DatabaseConnection.connect();
         db.prepare(
-            'INSERT INTO moderationTimeouts (serverId, userId, type, endTime, timerId) VALUES (?, ?, ?, ?, ?) ' +
+            'INSERT INTO moderationTimeouts (serverId, userId, type, startTime, endTime, timerId) VALUES (?, ?, ?, ?, ?, ?) ' +
             'ON CONFLICT(serverId, userId, type) DO UPDATE SET timerId = excluded.timerId',
-        ).run(serverId, userId, type, endTime, timerId);
+        ).run(serverId, userId, type, startTime, endTime, timerId);
         db.close();
     }
 

--- a/src/main/modules/moderation/classes/ModerationTimeout.ts
+++ b/src/main/modules/moderation/classes/ModerationTimeout.ts
@@ -7,6 +7,8 @@ export interface ModerationTimeout {
 
     type: ModActions;
 
+    startTime: number;
+
     endTime: number;
 
     timerId: number;


### PR DESCRIPTION
The bot would report the duration of ban/mute based on the duration passed into the setTimeout function, which is wrong if the bot restarts and a shortened duration is set.

This commit fixes that by adding the actual start time to all relevant methods and the timeout table in the database.