### PR TITLE
Fix some tests not being recognized by mocha on linux

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "app.js",
   "scripts": {
     "test": "docker-compose -f docker-compose.yml -f docker-compose.prod.yml -f docker-compose.test.yml up --build",
-    "docker-test": "mocha --exit build/test/**/*.js",
+    "docker-test": "mocha --exit --recursive build/test",
     "start": "docker-compose -f docker-compose.yml -f docker-compose.prod.yml up --build",
     "dev": "docker-compose -f docker-compose.yml up --build",
     "docker-dev": "ts-node-dev --transpile-only --poll src/main/App.ts",


### PR DESCRIPTION
Previously, tests in subdirectories deeper than build/test/<folder>
were not recognized by mocha.

Fix this by using the --recursive option instead of a glob.