### PR TITLE
DM the user before kick/ban instead of after (ADR-0005)

### DIFF
--- a/docs/adr/0004-dm-users-after-mute-kick-ban.md
+++ b/docs/adr/0004-dm-users-after-mute-kick-ban.md
@@ -1,5 +1,7 @@
 # DM the affected user after mute/kick/ban
 
+> Kick/ban's DM ordering is superseded by ADR-0005 (DM sent before the action, past a `lookup()` gate). Mute is unaffected and this document still applies to it as written.
+
 After a mute, kick, or ban, the bot now DMs the affected user (an "Action notice" — see `CONTEXT.md`) with the reason, duration if any, and which moderator performed it. This includes `WarnCommand`'s warn-threshold auto-escalation to ban/mute, not just directly-invoked commands — from the affected user's perspective there's no difference, and the notice matters more here since there's no moderator visibly typing a command to ask. The moderator field shows the bot itself for auto-escalation, matching what the DB log already records (`botId` as `modId`).
 
 `DiscordMemberPort` (ADR-0002) gets a new `dm(userId, options: { embeds: EmbedBuilder[] })` method, returning the same `MemberActionResult` as its other methods (resolving the user to DM them naturally produces their tag, same as `ban`/`kick`/`timeout`). The port stays domain-ignorant - it doesn't know what a "mute notice" is, only how to send a DM. The actual embed content is built by a new `ModUtils.buildActionNoticeEmbed(...)`, not on `Command` itself: `Command` is the generic base class every command family uses (Starboard, MsgChecker, Birthday, not just moderation), so putting mute/kick/ban-specific content there would leak domain knowledge into an unrelated shared class. `ModUtils` already holds moderation-specific shared formatting (`formatDuration`), so this is the same role.

--- a/docs/adr/0005-dm-user-before-kick-ban.md
+++ b/docs/adr/0005-dm-user-before-kick-ban.md
@@ -1,0 +1,16 @@
+# DM the affected user before kick/ban, not after
+
+ADR-0004 sends the Action notice DM only after mute/kick/ban is confirmed to have succeeded. For kick and ban this backfires: Discord requires a mutual server (or an existing DM channel) to open a DM, and kicking/banning a user from the only server they share with the bot severs that relationship before the DM is attempted — the notification silently fails in exactly the cases it matters most. We're moving kick/ban's DM to before the action, gated on a `lookup()` call first so an invalid or non-member target ID still gets today's "invalid user" error with no DM sent. Mute is unaffected by this change: it doesn't remove the member from the server, so mutual-server status is untouched and ADR-0004's after-action ordering already works fine there.
+
+## Considered Options
+
+- Reorder without a `lookup()` gate first — rejected: an invalid or typo'd user ID (the common moderator-error case, previously caught for free by `kick()`/`ban()`'s own internal fetch) would now get a "you were kicked" DM before the action fails, worse than sending nothing.
+- Keep DM after the action (status quo) — rejected: the DM systematically fails whenever the kicked/banned server was the only one shared with the bot, which is the common case for one-off moderation of a single troublesome user — the notification silently doesn't work for exactly the cases it matters most.
+
+## Consequences
+
+This reopens, narrowly, the false-positive risk ADR-0004 originally eliminated: if `lookup()` succeeds but the subsequent `kick()`/`ban()` call itself then fails (e.g. the bot's role sits below the target's in the hierarchy — only discoverable when Discord evaluates the actual mutation, not at lookup time), the user will already have received a DM claiming the action happened when it didn't. This is accepted as a documented tradeoff, narrower than the one ADR-0004 eliminated — scoped to kick/ban only (not mute), and only past the `lookup()` gate, so invalid/non-member IDs still produce zero false DMs.
+
+`WarnCommand`'s ban-escalation branch moves to the same lookup-then-DM-then-ban order; its mute-escalation branch is untouched.
+
+Every kick/ban now costs one extra Discord API call (`lookup`, already an existing `DiscordMemberPort` method per ADR-0002 — no new port surface needed) before the DM.

--- a/src/main/command/moderationcommands/BanCommand.ts
+++ b/src/main/command/moderationcommands/BanCommand.ts
@@ -77,6 +77,21 @@ export class BanCommand extends Command {
         if (reason.length > 512)
             reason = reason.substr(0, 512);
 
+        // Resolve the target before DMing them - an invalid/non-member id still gets today's
+        // error with no DM sent. See ADR-0005.
+        const lookupResult = await memberActions!.lookup(targetId);
+        if (!lookupResult.ok) {
+            await messageReply({ embeds: [this.generateUserIdErrorEmbed()] });
+            return this.COMMAND_SUCCESSFUL_COMMANDRESULT;
+        }
+
+        // Sent before the ban, while the target and bot still share this server - Discord
+        // requires a mutual server (or an existing DM channel) to open a DM, and a ban
+        // severs that. Best-effort: if the ban below then fails, the user will have
+        // already received this DM - an accepted, narrower tradeoff. See ADR-0005.
+        const noticeEmbed = ModUtils.buildActionNoticeEmbed('banned', serverName!, reason, userId!, duration);
+        const dmResult = await memberActions!.dm(targetId, { embeds: [noticeEmbed] });
+
         // Handle ban
         const result = await memberActions!.ban(
             targetId, { reason, deleteMessageSeconds: this.removeMsgs ? 86400 : 0 },
@@ -100,11 +115,6 @@ export class BanCommand extends Command {
                 duration, curTime, endTime, targetId, server.serverId, botId!, members!, emit!,
             );
         }
-
-        // Best-effort, sent only after the ban is confirmed - never claim it happened if it
-        // didn't. See ADR-0004.
-        const noticeEmbed = ModUtils.buildActionNoticeEmbed('banned', serverName!, reason, userId!, duration);
-        const dmResult = await memberActions!.dm(targetId, { embeds: [noticeEmbed] });
 
         await messageReply({ embeds: [this.generateValidEmbed(result.tag, reason, duration, dmResult.ok)] });
 

--- a/src/main/command/moderationcommands/KickCommand.ts
+++ b/src/main/command/moderationcommands/KickCommand.ts
@@ -60,6 +60,21 @@ export class KickCommand extends Command {
         if (reason.length > 512)
             reason = reason.substr(0, 512);
 
+        // Resolve the target before DMing them - an invalid/non-member id still gets today's
+        // error with no DM sent. See ADR-0005.
+        const lookupResult = await memberActions!.lookup(targetId);
+        if (!lookupResult.ok) {
+            await messageReply({ embeds: [this.generateUserIdErrorEmbed()] });
+            return this.COMMAND_SUCCESSFUL_COMMANDRESULT;
+        }
+
+        // Sent before the kick, while the target and bot still share this server - Discord
+        // requires a mutual server (or an existing DM channel) to open a DM, and a kick
+        // severs that. Best-effort: if the kick below then fails, the user will have
+        // already received this DM - an accepted, narrower tradeoff. See ADR-0005.
+        const noticeEmbed = ModUtils.buildActionNoticeEmbed('kicked', serverName!, reason, userId!);
+        const dmResult = await memberActions!.dm(targetId, { embeds: [noticeEmbed] });
+
         const result = await memberActions!.kick(targetId, reason);
         if (!result.ok) {
             await messageReply({ embeds: [this.generateUserIdErrorEmbed()] });
@@ -67,11 +82,6 @@ export class KickCommand extends Command {
         }
         ModerationLog.record(server.serverId, userId!, targetId,
                              this.type, ModUtils.getUnixTime(), emit!, reason);
-
-        // Best-effort, sent only after the kick is confirmed - never claim it happened if it
-        // didn't. See ADR-0004.
-        const noticeEmbed = ModUtils.buildActionNoticeEmbed('kicked', serverName!, reason, userId!);
-        const dmResult = await memberActions!.dm(targetId, { embeds: [noticeEmbed] });
 
         await messageReply({ embeds: [this.generateValidEmbed(result.tag, reason, dmResult.ok)] });
 

--- a/src/main/command/moderationcommands/WarnCommand.ts
+++ b/src/main/command/moderationcommands/WarnCommand.ts
@@ -109,6 +109,14 @@ export class WarnCommand extends Command {
             const reason = `**(AUTO)** ${numWarns} warns accumulated`;
             switch (type) {
                 case ModActions.BAN: {
+                    // Sent before the ban, while the mutual server relationship still holds
+                    // (see ADR-0005) - no extra lookup() here, targetId was already validated
+                    // by execute()'s lookup() moments earlier, and ADR-0002 deliberately
+                    // dropped this branch's redundant second fetch. Moderator is the bot
+                    // itself: this is an automatic escalation, not a moderator-issued command.
+                    const noticeEmbed = ModUtils.buildActionNoticeEmbed('banned', serverName, reason, botId, duration);
+                    await memberActions.dm(targetId, { embeds: [noticeEmbed] });
+
                     const result = await memberActions.ban(targetId, { reason });
                     if (!result.ok) {
                         log.warn(`[WarnCommand]: Unable to auto-ban ${targetId} in ${serverId} - unknown user!`);
@@ -123,12 +131,6 @@ export class WarnCommand extends Command {
                             duration, curTime, endTime, targetId, serverId, botId, members!, emit,
                         );
                     }
-
-                    // Best-effort, sent only after the ban is confirmed. Moderator is the bot
-                    // itself: this is an automatic escalation, not a moderator-issued command.
-                    // See ADR-0004.
-                    const noticeEmbed = ModUtils.buildActionNoticeEmbed('banned', serverName, reason, botId, duration);
-                    await memberActions.dm(targetId, { embeds: [noticeEmbed] });
                     break;
                 }
                 case ModActions.MUTE: {

--- a/src/main/modules/moderation/ModUtil.ts
+++ b/src/main/modules/moderation/ModUtil.ts
@@ -56,9 +56,10 @@ export class ModUtils {
     }
 
     /**
-     * Builds the "Action notice" DM embed sent to a user after a mute/kick/ban (see
-     * CONTEXT.md, ADR-0004) - not on Command, since Command is the generic base every
-     * command family uses (Starboard, MsgChecker, Birthday too), not just moderation.
+     * Builds the "Action notice" DM embed sent to a user for a mute/kick/ban (see
+     * CONTEXT.md, ADR-0004 for the embed's design; mute sends it after the action, kick/ban
+     * send it before - see ADR-0005) - not on Command, since Command is the generic base
+     * every command family uses (Starboard, MsgChecker, Birthday too), not just moderation.
      *
      * Pass duration to show it (formatted if a number, "Permanent" if null); omit it
      * entirely for actions with no duration concept, eg. kick.

--- a/src/test/command/moderationcommands/BanCommand.test.ts
+++ b/src/test/command/moderationcommands/BanCommand.test.ts
@@ -80,11 +80,13 @@ describe('BanCommand test suite', (): void => {
         const commandResult = await command.execute({ ...baseArgs(), messageReply: checkEmbed });
 
         commandResult.shouldCheckMessage.should.be.true;
-        memberActions.calls.length.should.equal(2);
-        memberActions.calls[0].method.should.equal('ban');
+        memberActions.calls.length.should.equal(3);
+        memberActions.calls[0].method.should.equal('lookup');
         memberActions.calls[0].userId.should.equal(targetId);
         memberActions.calls[1].method.should.equal('dm');
         memberActions.calls[1].userId.should.equal(targetId);
+        memberActions.calls[2].method.should.equal('ban');
+        memberActions.calls[2].userId.should.equal(targetId);
         const logs = ModerationLog.entries(serverId, { userId: targetId, type: ModActions.BAN });
         logs.length.should.equal(1);
         logs[0].reason!.should.equal('being bad');
@@ -117,6 +119,21 @@ describe('BanCommand test suite', (): void => {
     });
 
     it('Unknown user is reported and nothing is recorded', async (): Promise<void> => {
+        memberActions.nextLookupResult = { ok: false };
+        const command = new BanCommand([targetId]);
+        const checkEmbed = (msg: MessageReplyOptions): void => {
+            const embed = (msg!.embeds![0] as EmbedBuilder).data;
+            embed.color!.should.equal(EMBED_ERROR_COLOUR);
+        };
+        const commandResult = await command.execute({ ...baseArgs(), messageReply: checkEmbed });
+
+        commandResult.shouldCheckMessage.should.be.true;
+        memberActions.calls.length.should.equal(1);
+        memberActions.calls[0].method.should.equal('lookup');
+        ModerationLog.entries(serverId, { userId: targetId, type: ModActions.BAN }).length.should.equal(0);
+    });
+
+    it('Ban failing after a successful lookup still leaves the DM sent', async (): Promise<void> => {
         memberActions.nextResult = { ok: false };
         const command = new BanCommand([targetId]);
         const checkEmbed = (msg: MessageReplyOptions): void => {
@@ -126,6 +143,10 @@ describe('BanCommand test suite', (): void => {
         const commandResult = await command.execute({ ...baseArgs(), messageReply: checkEmbed });
 
         commandResult.shouldCheckMessage.should.be.true;
+        memberActions.calls.length.should.equal(3);
+        memberActions.calls[0].method.should.equal('lookup');
+        memberActions.calls[1].method.should.equal('dm');
+        memberActions.calls[2].method.should.equal('ban');
         ModerationLog.entries(serverId, { userId: targetId, type: ModActions.BAN }).length.should.equal(0);
     });
 });

--- a/src/test/command/moderationcommands/KickCommand.test.ts
+++ b/src/test/command/moderationcommands/KickCommand.test.ts
@@ -50,11 +50,13 @@ describe('KickCommand test suite', (): void => {
         const commandResult = await command.execute({ ...baseArgs(), messageReply: checkEmbed });
 
         commandResult.shouldCheckMessage.should.be.true;
-        memberActions.calls.length.should.equal(2);
-        memberActions.calls[0].method.should.equal('kick');
+        memberActions.calls.length.should.equal(3);
+        memberActions.calls[0].method.should.equal('lookup');
         memberActions.calls[0].userId.should.equal(targetId);
         memberActions.calls[1].method.should.equal('dm');
         memberActions.calls[1].userId.should.equal(targetId);
+        memberActions.calls[2].method.should.equal('kick');
+        memberActions.calls[2].userId.should.equal(targetId);
         ModerationLog.entries(serverId, { userId: targetId, type: ModActions.KICK }).length.should.equal(1);
     });
 
@@ -73,6 +75,21 @@ describe('KickCommand test suite', (): void => {
     });
 
     it('Unknown user is reported and nothing is recorded', async (): Promise<void> => {
+        memberActions.nextLookupResult = { ok: false };
+        const command = new KickCommand([targetId]);
+        const checkEmbed = (msg: MessageReplyOptions): void => {
+            const embed = (msg!.embeds![0] as EmbedBuilder).data;
+            embed.color!.should.equal(EMBED_ERROR_COLOUR);
+        };
+        const commandResult = await command.execute({ ...baseArgs(), messageReply: checkEmbed });
+
+        commandResult.shouldCheckMessage.should.be.true;
+        memberActions.calls.length.should.equal(1);
+        memberActions.calls[0].method.should.equal('lookup');
+        ModerationLog.entries(serverId, { userId: targetId, type: ModActions.KICK }).length.should.equal(0);
+    });
+
+    it('Kick failing after a successful lookup still leaves the DM sent', async (): Promise<void> => {
         memberActions.nextResult = { ok: false };
         const command = new KickCommand([targetId]);
         const checkEmbed = (msg: MessageReplyOptions): void => {
@@ -82,6 +99,10 @@ describe('KickCommand test suite', (): void => {
         const commandResult = await command.execute({ ...baseArgs(), messageReply: checkEmbed });
 
         commandResult.shouldCheckMessage.should.be.true;
+        memberActions.calls.length.should.equal(3);
+        memberActions.calls[0].method.should.equal('lookup');
+        memberActions.calls[1].method.should.equal('dm');
+        memberActions.calls[2].method.should.equal('kick');
         ModerationLog.entries(serverId, { userId: targetId, type: ModActions.KICK }).length.should.equal(0);
     });
 });

--- a/src/test/command/moderationcommands/WarnCommand.test.ts
+++ b/src/test/command/moderationcommands/WarnCommand.test.ts
@@ -40,7 +40,7 @@ describe('WarnCommand test suite', (): void => {
     const baseArgs = (): ReturnType<typeof baseCommandArgs> => baseCommandArgs(server, memberActions);
 
     it('Plain warn looks the user up and records the action, no escalation', async (): Promise<void> => {
-        memberActions.nextResult = { ok: true, tag: 'Target#0001' };
+        memberActions.nextLookupResult = { ok: true, tag: 'Target#0001' };
         const command = new WarnCommand([targetId, 'first', 'offence']);
         const checkEmbed = (msg: MessageReplyOptions): void => {
             const embed = (msg!.embeds![0] as EmbedBuilder).data;
@@ -56,7 +56,7 @@ describe('WarnCommand test suite', (): void => {
     });
 
     it('Unknown user is reported and nothing is recorded', async (): Promise<void> => {
-        memberActions.nextResult = { ok: false };
+        memberActions.nextLookupResult = { ok: false };
         const command = new WarnCommand([targetId]);
         const checkEmbed = (msg: MessageReplyOptions): void => {
             const embed = (msg!.embeds![0] as EmbedBuilder).data;
@@ -77,9 +77,9 @@ describe('WarnCommand test suite', (): void => {
         commandResult.shouldCheckMessage.should.be.true;
         memberActions.calls.length.should.equal(3);
         memberActions.calls[0].method.should.equal('lookup');
-        memberActions.calls[1].method.should.equal('ban');
+        memberActions.calls[1].method.should.equal('dm');
         memberActions.calls[1].userId.should.equal(targetId);
-        memberActions.calls[2].method.should.equal('dm');
+        memberActions.calls[2].method.should.equal('ban');
         ModerationLog.entries(serverId, { userId: targetId, type: ModActions.BAN }).length.should.equal(1);
     });
 
@@ -93,7 +93,8 @@ describe('WarnCommand test suite', (): void => {
         const commandResult = await command.execute({ ...baseArgs(), members, messageReply: noopMessageReply });
 
         commandResult.shouldCheckMessage.should.be.true;
-        memberActions.calls[1].method.should.equal('ban');
+        memberActions.calls[1].method.should.equal('dm');
+        memberActions.calls[2].method.should.equal('ban');
         const logs = ModerationLog.entries(serverId, { userId: targetId, type: ModActions.BAN });
         logs.length.should.equal(1);
         logs[0].timeout!.should.equal(3600);

--- a/src/test/modules/moderation/FakeMemberAdapter.ts
+++ b/src/test/modules/moderation/FakeMemberAdapter.ts
@@ -9,13 +9,18 @@ export interface RecordedCall {
 }
 
 /**
- * Test double for DiscordMemberPort. lookup/ban/unban/kick/timeout return whatever
- * `nextResult` is currently set to (default: success); dm() has its own `nextDmResult`
- * (default: success) so a test can make the main action succeed while the DM fails, or
- * vice versa. Every call is recorded for assertions.
+ * Test double for DiscordMemberPort. ban/unban/kick/timeout return whatever `nextResult`
+ * is currently set to (default: success); lookup() has its own `nextLookupResult`
+ * (default: success) so a test can simulate an unresolvable target independently of
+ * whether the mutating call would have succeeded (see ADR-0005 - kick/ban now lookup()
+ * before DMing, so a lookup failure and a kick/ban failure are distinguishable
+ * scenarios). dm() likewise has its own `nextDmResult`. Every call is recorded for
+ * assertions.
  */
 export class FakeMemberAdapter implements DiscordMemberPort {
     public nextResult: MemberActionResult = { ok: true, tag: 'TestUser#0001' };
+
+    public nextLookupResult: MemberActionResult = { ok: true, tag: 'TestUser#0001' };
 
     public nextDmResult: MemberActionResult = { ok: true, tag: 'TestUser#0001' };
 
@@ -23,7 +28,7 @@ export class FakeMemberAdapter implements DiscordMemberPort {
 
     public async lookup(userId: string): Promise<MemberActionResult> {
         this.calls.push({ method: 'lookup', userId, args: [] });
-        return this.nextResult;
+        return this.nextLookupResult;
     }
 
     public async ban(userId: string, options: BanOptions): Promise<MemberActionResult> {


### PR DESCRIPTION
## Summary
- Discord requires a mutual server to open a DM. ADR-0004 sent the Action-notice DM only after mute/kick/ban succeeded, which silently broke the notice for kick/ban whenever the affected server was the only one shared with the bot — exactly the case where notifying the user matters most.
- Kick/ban (and WarnCommand's ban-escalation branch) now `lookup()` the target, send the DM, then perform the action. An invalid/non-member target ID still gets today's error with no DM sent. Mute is untouched — it doesn't remove the member from the server, so ADR-0004's after-action ordering still holds there.
- See `docs/adr/0005-dm-user-before-kick-ban.md` (new) and the pointer note added to `docs/adr/0004-dm-users-after-mute-kick-ban.md`.

## Test plan
- [x] Full test suite (251 passing) via `docker-compose -f docker-compose.yml -f docker-compose.prod.yml -f docker-compose.test.yml up --build`
- [x] `tsc -p . --noEmit` typecheck clean
- [x] `eslint ./src/**` clean
- [x] `/code-review` (Standards + Spec axes) — no hard findings on either axis

🤖 Generated with [Claude Code](https://claude.com/claude-code)